### PR TITLE
chore: change EAS project ID

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -60,7 +60,7 @@
         "origin": false
       },
       "eas": {
-        "projectId": "3a624e70-9938-49e7-9582-f8dc70f67cfb"
+        "projectId": "1499577b-a7ec-4324-97b6-673c4ec73f19"
       }
     },
     "owner": "bertytechnologies"


### PR DESCRIPTION
When I created the EAS Expo project, I put `boards2-mobile` as name. But later I changed it in the code base to `boards2`, so I created again the project on EAS.
This PR set the new project ID.